### PR TITLE
Added MiniIsolation for Electrons and Muons using the SUSY prescription

### DIFF
--- a/python/b2gedmntuples_cff.py
+++ b/python/b2gedmntuples_cff.py
@@ -98,6 +98,10 @@ muonVars = (
         quantity = cms.untracked.string("userFloat('iso04')")
    ),
    cms.PSet(
+        tag = cms.untracked.string("MiniIso"),
+        quantity = cms.untracked.string("userFloat('miniIso')")
+   ),
+   cms.PSet(
         tag = cms.untracked.string("D0"),
         quantity = cms.untracked.string("dB")
    ),
@@ -593,6 +597,10 @@ electronVars = (
       quantity = cms.untracked.string("userFloat('iso03db')")
       ),
     cms.PSet(
+      tag = cms.untracked.string("MiniIso"),
+      quantity = cms.untracked.string("userFloat('miniIso')")
+      ),
+   cms.PSet(
       tag = cms.untracked.string("rho"),
       quantity = cms.untracked.string("userFloat('rho')")
       ),

--- a/src/ElectronUserData.cc
+++ b/src/ElectronUserData.cc
@@ -14,6 +14,9 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
+// MiniIsolation
+#include "Isolations.h"
+
 // trigger
 #include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
@@ -111,6 +114,9 @@ void ElectronUserData::produce( edm::Event& iEvent, const edm::EventSetup& iSetu
   
   auto_ptr<vector<pat::Electron> > eleColl( new vector<pat::Electron> (*eleHandle) );
 
+  //PackedPFCands for Mini-iso
+  edm::Handle<pat::PackedCandidateCollection> packedPFCands;
+  iEvent.getByLabel("packedPFCandidates", packedPFCands);
 
 
   Handle<reco::BeamSpot> bsHandle;
@@ -194,6 +200,7 @@ void ElectronUserData::produce( edm::Event& iEvent, const edm::EventSetup& iSetu
     float hoe = el.hadronicOverEm();
     float absiso = pfIso.sumChargedHadronPt + max(0.0 , pfIso.sumNeutralHadronEt + pfIso.sumPhotonEt - 0.5 * pfIso.sumPUPt );
     float relIsoWithDBeta_ = absiso/el.pt();
+    double miniIso = getPFMiniIsolation(packedPFCands, dynamic_cast<const reco::Candidate *>(&el), 0.05, 0.2, 10., false);
     double EA = getEA(el.eta());
     //double rho = 1.0;
     float absiso_EA = pfIso.sumChargedHadronPt + max(0.0 , pfIso.sumNeutralHadronEt + pfIso.sumPhotonEt - rho * EA );
@@ -243,6 +250,7 @@ void ElectronUserData::produce( edm::Event& iEvent, const edm::EventSetup& iSetu
     el.addUserFloat("hasMatchConv",     hasMatchConv);   
     el.addUserFloat("iso03db",    relIsoWithDBeta_);
     el.addUserFloat("iso03",       relIsoWithEA_);
+    el.addUserFloat("miniIso",     miniIso);
     el.addUserFloat("sumChargedHadronPt",   pfIso.sumChargedHadronPt);
     el.addUserFloat("sumNeutralHadronEt", pfIso.sumNeutralHadronEt  );
     el.addUserFloat("sumPhotonEt",  pfIso.sumPhotonEt );

--- a/src/Isolations.cc
+++ b/src/Isolations.cc
@@ -1,0 +1,74 @@
+#include "Isolations.h"
+#include "DataFormats/Math/interface/deltaR.h"
+
+// Source:
+// https://hypernews.cern.ch/HyperNews/CMS/get/susy/1991.html
+// https://github.com/manuelfs/CfANtupler/blob/master/minicfa/interface/miniAdHocNTupler.h#L54
+
+double getPFMiniIsolation(edm::Handle<pat::PackedCandidateCollection> pfcands,
+		      const reco::Candidate* ptcl,  
+		      double r_iso_min, double r_iso_max, double kt_scale,
+		      bool charged_only) {
+
+  if (ptcl->pt()<5.) return 99999.;
+
+  double deadcone_nh(0.), deadcone_ch(0.), deadcone_ph(0.), deadcone_pu(0.);
+  if(ptcl->isElectron()) {
+    if (fabs(ptcl->eta())>1.479) {deadcone_ch = 0.015; deadcone_pu = 0.015; deadcone_ph = 0.08;}
+  } else if(ptcl->isMuon()) {
+    deadcone_ch = 0.0001; deadcone_pu = 0.01; deadcone_ph = 0.01;deadcone_nh = 0.01;  
+  } else {
+    //deadcone_ch = 0.0001; deadcone_pu = 0.01; deadcone_ph = 0.01;deadcone_nh = 0.01; // maybe use muon cones??
+  }
+
+  double iso_nh(0.); double iso_ch(0.); 
+  double iso_ph(0.); double iso_pu(0.);
+  double ptThresh(0.5);
+  if(ptcl->isElectron()) ptThresh = 0;
+  double r_iso = std::max(r_iso_min,std::min(r_iso_max, kt_scale/ptcl->pt()));
+  for (const pat::PackedCandidate &pfc : *pfcands) {
+    if (abs(pfc.pdgId())<7) continue;
+
+    double dr = reco::deltaR(pfc, *ptcl);
+    if (dr > r_iso) continue;
+      
+    //////////////////  NEUTRALS  /////////////////////////
+    if (pfc.charge()==0){
+      if (pfc.pt()>ptThresh) {
+	/////////// PHOTONS ////////////
+	if (abs(pfc.pdgId())==22) {
+	  if(dr < deadcone_ph) continue;
+	  iso_ph += pfc.pt();
+	  /////////// NEUTRAL HADRONS ////////////
+	    } else if (abs(pfc.pdgId())==130) {
+	  if(dr < deadcone_nh) continue;
+	  iso_nh += pfc.pt();
+	}
+      }
+      //////////////////  CHARGED from PV  /////////////////////////
+    } else if (pfc.fromPV()>1){
+      if (abs(pfc.pdgId())==211) {
+	if(dr < deadcone_ch) continue;
+	iso_ch += pfc.pt();
+      }
+      //////////////////  CHARGED from PU  /////////////////////////
+    } else {
+      if (pfc.pt()>ptThresh){
+	if(dr < deadcone_pu) continue;
+	iso_pu += pfc.pt();
+      }
+    }
+  }
+  double iso(0.);
+  if (charged_only){
+    iso = iso_ch;
+  } else {
+    iso = iso_ph + iso_nh;
+    iso -= 0.5*iso_pu;
+    if (iso>0) iso += iso_ch;
+    else iso = iso_ch;
+  }
+  iso = iso/ptcl->pt();
+
+  return iso;
+}

--- a/src/Isolations.h
+++ b/src/Isolations.h
@@ -1,0 +1,6 @@
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+
+double getPFMiniIsolation(edm::Handle<pat::PackedCandidateCollection> pfcands,
+			  const reco::Candidate* ptcl,  
+			  double r_iso_min, double r_iso_max, double kt_scale,
+			  bool charged_only);

--- a/src/MuonUserData.cc
+++ b/src/MuonUserData.cc
@@ -15,6 +15,9 @@
 #include "DataFormats/PatCandidates/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonPFIsolation.h"
 
+// MiniIsolation
+#include "Isolations.h"
+
 // Vertex
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
@@ -139,6 +142,10 @@ void MuonUserData::produce( edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::Handle<std::vector<pat::Muon> > muonHandle;
   iEvent.getByLabel(muLabel_, muonHandle);
   auto_ptr<vector<pat::Muon> > muonColl( new vector<pat::Muon> (*muonHandle) );
+  
+  //PackedPFCands for Mini-isolation
+  edm::Handle<pat::PackedCandidateCollection> packedPFCands;
+  iEvent.getByLabel("packedPFCandidates", packedPFCands);
 
   /////////  /////////  /////////  /////////  /////////  /////////  /////////  /////////  /////////
   // TRIGGER (this is not really needed ...)
@@ -247,6 +254,7 @@ void MuonUserData::produce( edm::Event& iEvent, const edm::EventSetup& iSetup) {
     double sumPUPt            = m.pfIsolationR04().sumPUPt;
     double pt                 = m.pt();
     double iso04 = (sumChargedHadronPt+TMath::Max(0.,sumNeutralHadronPt+sumPhotonPt-0.5*sumPUPt))/pt;
+    double miniIso = getPFMiniIsolation(packedPFCands, dynamic_cast<const reco::Candidate *>(&m), 0.05, 0.2, 10., false);
 
     // trigger matched 
 
@@ -279,6 +287,7 @@ void MuonUserData::produce( edm::Event& iEvent, const edm::EventSetup& iSetup) {
     m.addUserFloat("dxyErr",          dxyErr);
     m.addUserFloat("dzErr",          dzErr);
     m.addUserFloat("iso04",       iso04);
+    m.addUserFloat("miniIso",     miniIso);
     
     m.addUserFloat("HLTmuonEta",   hltEta);
     m.addUserFloat("HLTmuonPhi",   hltPhi);


### PR DESCRIPTION
Dear B2G,

In this commit I added the computation of the MiniIsolation for Electrons/Muons using the SUSY prescription posted here:
https://hypernews.cern.ch/HyperNews/CMS/get/susy/1991.html
code:
https://github.com/manuelfs/CfANtupler/blob/master/minicfa/interface/miniAdHocNTupler.h#L54-L120

I hope this will be a useful addition. As a sidenote: The B2G 2D cut computation can be added to Isolations.cc later if needed.

Best regards,
Janos Karancsi
