### PR TITLE
Added MiniIsolation for Electrons and Muons using the SUSY prescription

### DIFF
--- a/python/b2gedmntuples_cff.py
+++ b/python/b2gedmntuples_cff.py
@@ -98,6 +98,10 @@ muonVars = (
         quantity = cms.untracked.string("userFloat('iso04')")
    ),
    cms.PSet(
+        tag = cms.untracked.string("MiniIso"),
+        quantity = cms.untracked.string("userFloat('miniIso')")
+   ),
+   cms.PSet(
         tag = cms.untracked.string("D0"),
         quantity = cms.untracked.string("dB")
    ),
@@ -616,6 +620,10 @@ electronVars = (
     cms.PSet(
       tag = cms.untracked.string("Iso03db"),
       quantity = cms.untracked.string("userFloat('iso03db')")
+      ),
+    cms.PSet(
+      tag = cms.untracked.string("MiniIso"),
+      quantity = cms.untracked.string("userFloat('miniIso')")
       ),
     cms.PSet(
       tag = cms.untracked.string("rho"),

--- a/src/Isolations.cc
+++ b/src/Isolations.cc
@@ -1,0 +1,74 @@
+#include "Isolations.h"
+#include "DataFormats/Math/interface/deltaR.h"
+
+// Source:
+// https://hypernews.cern.ch/HyperNews/CMS/get/susy/1991.html
+// https://github.com/manuelfs/CfANtupler/blob/master/minicfa/interface/miniAdHocNTupler.h#L54
+
+double getPFMiniIsolation(edm::Handle<pat::PackedCandidateCollection> pfcands,
+		      const reco::Candidate* ptcl,  
+		      double r_iso_min, double r_iso_max, double kt_scale,
+		      bool charged_only) {
+
+  if (ptcl->pt()<5.) return 99999.;
+
+  double deadcone_nh(0.), deadcone_ch(0.), deadcone_ph(0.), deadcone_pu(0.);
+  if(ptcl->isElectron()) {
+    if (fabs(ptcl->eta())>1.479) {deadcone_ch = 0.015; deadcone_pu = 0.015; deadcone_ph = 0.08;}
+  } else if(ptcl->isMuon()) {
+    deadcone_ch = 0.0001; deadcone_pu = 0.01; deadcone_ph = 0.01;deadcone_nh = 0.01;  
+  } else {
+    //deadcone_ch = 0.0001; deadcone_pu = 0.01; deadcone_ph = 0.01;deadcone_nh = 0.01; // maybe use muon cones??
+  }
+
+  double iso_nh(0.); double iso_ch(0.); 
+  double iso_ph(0.); double iso_pu(0.);
+  double ptThresh(0.5);
+  if(ptcl->isElectron()) ptThresh = 0;
+  double r_iso = std::max(r_iso_min,std::min(r_iso_max, kt_scale/ptcl->pt()));
+  for (const pat::PackedCandidate &pfc : *pfcands) {
+    if (abs(pfc.pdgId())<7) continue;
+
+    double dr = reco::deltaR(pfc, *ptcl);
+    if (dr > r_iso) continue;
+      
+    //////////////////  NEUTRALS  /////////////////////////
+    if (pfc.charge()==0){
+      if (pfc.pt()>ptThresh) {
+	/////////// PHOTONS ////////////
+	if (abs(pfc.pdgId())==22) {
+	  if(dr < deadcone_ph) continue;
+	  iso_ph += pfc.pt();
+	  /////////// NEUTRAL HADRONS ////////////
+	    } else if (abs(pfc.pdgId())==130) {
+	  if(dr < deadcone_nh) continue;
+	  iso_nh += pfc.pt();
+	}
+      }
+      //////////////////  CHARGED from PV  /////////////////////////
+    } else if (pfc.fromPV()>1){
+      if (abs(pfc.pdgId())==211) {
+	if(dr < deadcone_ch) continue;
+	iso_ch += pfc.pt();
+      }
+      //////////////////  CHARGED from PU  /////////////////////////
+    } else {
+      if (pfc.pt()>ptThresh){
+	if(dr < deadcone_pu) continue;
+	iso_pu += pfc.pt();
+      }
+    }
+  }
+  double iso(0.);
+  if (charged_only){
+    iso = iso_ch;
+  } else {
+    iso = iso_ph + iso_nh;
+    iso -= 0.5*iso_pu;
+    if (iso>0) iso += iso_ch;
+    else iso = iso_ch;
+  }
+  iso = iso/ptcl->pt();
+
+  return iso;
+}

--- a/src/Isolations.h
+++ b/src/Isolations.h
@@ -1,0 +1,6 @@
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+
+double getPFMiniIsolation(edm::Handle<pat::PackedCandidateCollection> pfcands,
+			  const reco::Candidate* ptcl,  
+			  double r_iso_min, double r_iso_max, double kt_scale,
+			  bool charged_only);

--- a/test/b2gedmntuples_cfg.py
+++ b/test/b2gedmntuples_cfg.py
@@ -279,6 +279,7 @@ process.muonUserData = cms.EDProducer(
     'MuonUserData',
     muonLabel = cms.InputTag("skimmedPatMuons"),
     pv        = cms.InputTag(pvLabel),
+    packedPFCands = cms.InputTag("packedPFCandidates"),
     ### TTRIGGER ###
     triggerResults = cms.InputTag(triggerResultsLabel,"","HLT"),
     triggerSummary = cms.InputTag(triggerSummaryLabel,"","HLT"),
@@ -317,6 +318,7 @@ process.electronUserData = cms.EDProducer(
     'ElectronUserData',
     eleLabel   = cms.InputTag("skimmedPatElectrons"),
     pv         = cms.InputTag(pvLabel),
+    packedPFCands = cms.InputTag("packedPFCandidates"),
     conversion = cms.InputTag(convLabel),
     rho        = cms.InputTag(rhoLabel),
     triggerResults = cms.InputTag(triggerResultsLabel),


### PR DESCRIPTION
Dear B2G,

In this commit I added the computation of the MiniIsolation for Electrons/Muons using the SUSY prescription posted here:
https://hypernews.cern.ch/HyperNews/CMS/get/susy/1991.html
code:
https://github.com/manuelfs/CfANtupler/blob/master/minicfa/interface/miniAdHocNTupler.h#L54-L120

Best regards,
Janos Karancsi
