### PR TITLE
Add ICHEP16 GTs, new option for reHLT datasets, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ This is a prroduction version of the B2G EDMNtuples. Updates since last producti
  * Make a new CMSSW area:
 ```
 setenv SCRAM_ARCH slc6_amd64_gcc530 (or in bash: export SCRAM_ARCH=slc6_amd64_gcc530)
-cmsrel CMSSW_8_0_10_patch2
-cd CMSSW_8_0_10_patch2/src
+cmsrel CMSSW_8_0_14
+cd CMSSW_8_0_14/src
 cmsenv
 ```
  * Temporary checkouts:
@@ -22,7 +22,7 @@ cmsenv
 ```
  * Clone the github repository
 ```
-git clone git@github.com:cmsb2g/B2GAnaFW.git Analysis/B2GAnaFW -b CMSSW_8_0_X_V1
+git clone git@github.com:cmsb2g/B2GAnaFW.git Analysis/B2GAnaFW -b CMSSW_8_0_X_V2
 git clone git@github.com:cms-jet/JetToolbox.git JMEAnalysis/JetToolbox -b jetToolbox_763
 ```
  * Compile


### PR DESCRIPTION
In this PR, the following changes were made:
- Added new GTs for ICHEP datasets
- There is no GT for FastSim --> use sqlite file for the Fastsim JEC
- Added new dataprocessing option for reHLT MCs (HLT2 process name)
- Added new separate option to use sqlite file for JER
- Update readme to use latest CMSSW release (have to be >8_0_12)

More info:
https://hypernews.cern.ch/HyperNews/CMS/get/jes/609/1.html
https://twiki.cern.ch/twiki/bin/view/CMS/JECDataMC#Recommended_for_Data
