### PR TITLE
Update MET Filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@ setenv CMSSW_GIT_REFERENCE /cvmfs/cms.cern.ch/cmssw.git.daily
 git cms-init
 
 ```
- * Top branch needed to run updated double b tagger training on AK8 jets
+ * Top branch needed to run updated double b tagger training on AK8 jets, and latest Run II MET filters
 ```
 git fetch --tags btv-cmssw
 
 git cms-merge-topic -u cms-btv-pog:BoostedDoubleSVTaggerV3-WithWeightFiles-v1_from-CMSSW_8_0_8_patch1
+git cms-merge-topic -u cms-met:CMSSW_8_0_X-METFilterUpdate
 
 ```
  * Temporary checkouts:

--- a/test/b2gedmntuples_cfg.py
+++ b/test/b2gedmntuples_cfg.py
@@ -456,6 +456,21 @@ if ("Data" in options.DataProcessing and  options.forceResiduals):
     process.shiftedPatJetEnUp.jetCorrLabelUpToL3Res = cms.InputTag("ak4PFCHSL1FastL2L3Corrector")
 ### ------------------------------------------------------------------
 
+### -------------------------------------------------------------------
+### Latest Run II MET Filter recommendations
+### -------------------------------------------------------------------
+
+# Using recipe:
+# https://twiki.cern.ch/twiki/bin/view/CMS/MissingETOptionalFiltersRun2?rev=99#How_to_run_the_Bad_Charged_Hadro
+
+process.load('RecoMET.METFilters.BadPFMuonFilter_cfi')
+process.BadPFMuonFilter.muons = cms.InputTag("slimmedMuons")
+process.BadPFMuonFilter.PFCandidates = cms.InputTag("packedPFCandidates")
+
+process.load('RecoMET.METFilters.BadChargedCandidateFilter_cfi')
+process.BadChargedCandidateFilter.muons = cms.InputTag("slimmedMuons")
+process.BadChargedCandidateFilter.PFCandidates = cms.InputTag("packedPFCandidates")
+
 
 ### ------------------------------------------------------------------
 ### Configure UserData
@@ -844,6 +859,8 @@ process.edmNtuplesOut = cms.OutputModule(
     "keep *_TriggerUserData*_trigger*_*",
     "keep *_fixedGridRhoFastjetAll_*_*",
     "keep *_eventUserData_*_*",
+    "keep *_BadPFMuonFilter_*_*",
+    "keep *_BadChargedCandidateFilter_*_*",
     "keep *_eeBadScFilter_*_*"
     ),
     dropMetaData = cms.untracked.string('ALL'),


### PR DESCRIPTION
Content of the PR:
- Update to latest Run II MET filter recommendations for 2016 data, found here:
  https://twiki.cern.ch/twiki/bin/view/CMS/MissingETOptionalFiltersRun2#How_to_run_the_Bad_Charged_Hadro
- Update recipe (need to merge a branch from the JetMET POG)
