### PR TITLE
Cmssw 8 0 x v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,9 @@ setenv CMSSW_GIT_REFERENCE /cvmfs/cms.cern.ch/cmssw.git.daily
 git cms-init
 
 ```
- * Top branch needed to run updated double b tagger training on AK8 jets
+ * Necessary for the VID tool and the EGamma Ids
 ```
-git fetch --tags btv-cmssw
-
-git cms-merge-topic -u cms-btv-pog:BoostedDoubleSVTaggerV3-WithWeightFiles-v1_from-CMSSW_8_0_8_patch1
+git cms-merge-topic ikrav:egm_id_80X_v1
 
 ```
  * Temporary checkouts:

--- a/python/b2gedmntuples_cff.py
+++ b/python/b2gedmntuples_cff.py
@@ -931,16 +931,33 @@ electronVars = (
         quantity = cms.untracked.string("userFloat('vidLoose')")
         ),
     cms.PSet(
-        tag = cms.untracked.string("vidTight"),
-        quantity = cms.untracked.string("userFloat('vidTight')")
-        ),
-    cms.PSet(
         tag = cms.untracked.string("vidMedium"),
         quantity = cms.untracked.string("userFloat('vidMedium')")
         ),
     cms.PSet(
+        tag = cms.untracked.string("vidTight"),
+        quantity = cms.untracked.string("userFloat('vidTight')")
+        ),
+    cms.PSet(
         tag = cms.untracked.string("vidHEEP"),
         quantity = cms.untracked.string("userFloat('vidHEEP')")
+        ),
+    # IDs sans iso
+    cms.PSet(
+        tag = cms.untracked.string("vidVetonosiso"),
+        quantity = cms.untracked.string("userFloat('vidVetonoiso')")
+        ),
+    cms.PSet(
+        tag = cms.untracked.string("vidLoosenoiso"),
+        quantity = cms.untracked.string("userFloat('vidLoosenoiso')")
+        ),
+    cms.PSet(
+        tag = cms.untracked.string("vidMediumnoiso"),
+        quantity = cms.untracked.string("userFloat('vidMediumnoiso')")
+        ),
+    cms.PSet(
+        tag = cms.untracked.string("vidTightnoiso"),
+        quantity = cms.untracked.string("userFloat('vidTightnoiso')")
         ),
     cms.PSet(
         tag = cms.untracked.string("vidHEEPnoiso"),

--- a/python/b2gedmntuples_cff.py
+++ b/python/b2gedmntuples_cff.py
@@ -944,7 +944,7 @@ electronVars = (
         ),
     # IDs sans iso
     cms.PSet(
-        tag = cms.untracked.string("vidVetonosiso"),
+        tag = cms.untracked.string("vidVetonoiso"),
         quantity = cms.untracked.string("userFloat('vidVetonoiso')")
         ),
     cms.PSet(

--- a/test/b2gedmntuples_cfg.py
+++ b/test/b2gedmntuples_cfg.py
@@ -632,12 +632,11 @@ process.electronUserData = cms.EDProducer(
     triggerSummary = cms.InputTag(triggerSummaryLabel,"",hltProcess),
     hltElectronFilter  = cms.InputTag(hltElectronFilterLabel),  ##trigger matching code to be fixed!
     hltPath             = cms.string("HLT_Mu8_Ele17_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL"),
-    electronVetoIdMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-veto"),
-    electronLooseIdMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-loose"),
-    electronMediumIdMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-medium"),
-    electronTightIdMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-tight"),
-    electronHEEPIdMap = cms.InputTag("egmGsfElectronIDs:heepElectronID-HEEPV60"), 
-    eleMediumIdFullInfoMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-medium"),
+    eleVetoIdFullInfoMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-veto"),
+    eleLooseIdFullInfoMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-loose"),
+    eleMediumIdFullInfoMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-medium"),
+    eleTightIdFullInfoMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-tight"),
+    eleHEEPIdIdFullInfoMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-HEEPV60"),
     eleIdVerbose = cms.bool(False)
     )
 
@@ -697,8 +696,9 @@ for idmod in my_phoid_modules:
 
 #
 
-my_eid_modules = ['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Spring15_25ns_V1_cff',
-    'RecoEgamma.ElectronIdentification.Identification.heepElectronID_HEEPV60_cff']
+my_eid_modules = ['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Summer16_80X_V1_cff',
+    'RecoEgamma.ElectronIdentification.Identification.heepElectronID_HEEPV60_cff',
+    'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Spring15_25ns_V1_cff']
 for idmod in my_eid_modules:
   setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
 

--- a/test/b2gedmntuples_cfg.py
+++ b/test/b2gedmntuples_cfg.py
@@ -697,8 +697,7 @@ for idmod in my_phoid_modules:
 #
 
 my_eid_modules = ['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Summer16_80X_V1_cff',
-    'RecoEgamma.ElectronIdentification.Identification.heepElectronID_HEEPV60_cff',
-    'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Spring15_25ns_V1_cff']
+    'RecoEgamma.ElectronIdentification.Identification.heepElectronID_HEEPV60_cff']
 for idmod in my_eid_modules:
   setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
 


### PR DESCRIPTION
Fixed a typo. 

General changes : 

Updated electron variables to mirror official recommendations – how they are used in the VID – same methods. This was neccesary and users reported difference in the previous weeks. 

2) New 80X ID maps integrated
3) 80X ID maps sans Iso integrated also. 
- This means excluding Pf ea Rel iso for standard working points 
- TrackPtIso + GsfEleEmHadD1IsoRhoCut for heep.

4) I have removed the preIchep recommendations - ie the previous IDs basically. If users need this I can add them. 
