### PR TITLE
Electron ID fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ setenv CMSSW_GIT_REFERENCE /cvmfs/cms.cern.ch/cmssw.git.daily
 git cms-init
 
 ```
- * Necessary for the VID tool and the EGamma Ids
+ * Necessary for the VID tool and the EGamma Ids (and a temporary fix for loose cut based ID)
 ```
 git cms-merge-topic ikrav:egm_id_80X_v1
+sed -i "51s/0.0477/0.00477/" RecoEgamma/ElectronIdentification/python/Identification/cutBasedElectronID_Summer16_80X_V1_cff.py
 ```
  * Apply latest Run II MET filters that are not in MINIAOD
 ```

--- a/python/b2gedmntuples_cff.py
+++ b/python/b2gedmntuples_cff.py
@@ -890,6 +890,10 @@ electronVars = (
       quantity = cms.untracked.string("deltaEtaSuperClusterTrackAtVtx")
       ),
     cms.PSet(
+      tag = cms.untracked.string("dEtaInSeed"),
+      quantity = cms.untracked.string("userFloat('dEtaInSeed')")
+      ),
+    cms.PSet(
         tag = cms.untracked.string("dPhiIn"),
         quantity = cms.untracked.string("deltaPhiSuperClusterTrackAtVtx")
         ),

--- a/src/ElectronUserData.cc
+++ b/src/ElectronUserData.cc
@@ -93,6 +93,7 @@ ElectronUserData::ElectronUserData(const edm::ParameterSet& iConfig):
    triggerSummaryLabel_(consumes<trigger::TriggerEvent>(iConfig.getParameter<edm::InputTag>("triggerSummary"))),
    hltElectronFilterLabel_ (iConfig.getParameter<edm::InputTag>("hltElectronFilter")),   //trigger objects we want to match
    hltPath_ (iConfig.getParameter<std::string>("hltPath")),
+   electronHEEPIdMapToken_(consumes<edm::ValueMap<vid::CutFlowResult> >(iConfig.getParameter<edm::InputTag>("eleHEEPIdIdFullInfoMap"))),
    eleVetoIdFullInfoMapToken_(consumes<edm::ValueMap<vid::CutFlowResult> >(iConfig.getParameter<edm::InputTag>("eleVetoIdFullInfoMap"))),
    eleLooseIdFullInfoMapToken_(consumes<edm::ValueMap<vid::CutFlowResult> >(iConfig.getParameter<edm::InputTag>("eleLooseIdFullInfoMap"))),
    eleMediumIdFullInfoMapToken_(consumes<edm::ValueMap<vid::CutFlowResult> >(iConfig.getParameter<edm::InputTag>("eleMediumIdFullInfoMap"))),
@@ -220,7 +221,7 @@ void ElectronUserData::produce( edm::Event& iEvent, const edm::EventSetup& iSetu
 
 
     //Cut variables     
-    float dEtaIn = el.superCluster().isNonnull() && el.superCluster()->seed().isNonnull() ? el.deltaEtaSuperClusterTrackAtVtx() - el.superCluster()->eta() + el.superCluster()->seed()->eta() : std::numeric_limits<float>::max();  // the cutID uses the absolute of this variable
+    float dEtaInSeed = el.superCluster().isNonnull() && el.superCluster()->seed().isNonnull() ? el.deltaEtaSuperClusterTrackAtVtx() - el.superCluster()->eta() + el.superCluster()->seed()->eta() : std::numeric_limits<float>::max();  // the cutID uses the absolute of this variable
     float dPhiIn = el.deltaPhiSuperClusterTrackAtVtx(); // the cutID uses the absolute of this variable
     float full5x5 = el.full5x5_sigmaIetaIeta();
     float hoe = el.hadronicOverEm();
@@ -279,7 +280,7 @@ void ElectronUserData::produce( edm::Event& iEvent, const edm::EventSetup& iSetu
 
     fullCutFlowData = (*loose_id_cutflow_data)[elPtr];
     maskedCutFlowData = fullCutFlowData.getCutFlowResultMasking(cutIndexToMask);
-    bool vidLoose_noiso   =  (int) maskedCutFlowData.cutFlowPassed();\
+    bool vidLoose_noiso   =  (int) maskedCutFlowData.cutFlowPassed();
 
     fullCutFlowData = (*medium_id_cutflow_data)[elPtr];
     maskedCutFlowData = fullCutFlowData.getCutFlowResultMasking(cutIndexToMask);
@@ -304,7 +305,7 @@ void ElectronUserData::produce( edm::Event& iEvent, const edm::EventSetup& iSetu
       printCutFlowResult(fullCutFlowData);
     }
 
-    el.addUserFloat("dEtaIn",      dEtaIn);
+    el.addUserFloat("dEtaInSeed",  dEtaInSeed);
     el.addUserFloat("dPhiIn",      dPhiIn);
     el.addUserFloat("full5x5",     full5x5);
     el.addUserFloat("hoe",         hoe);

--- a/test/b2gedmntuples_cfg.py
+++ b/test/b2gedmntuples_cfg.py
@@ -651,7 +651,7 @@ process.electronUserData = cms.EDProducer(
     eleLooseIdFullInfoMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-loose"),
     eleMediumIdFullInfoMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-medium"),
     eleTightIdFullInfoMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-tight"),
-    eleHEEPIdIdFullInfoMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-HEEPV60"),
+    eleHEEPIdIdFullInfoMap = cms.InputTag("egmGsfElectronIDs:heepElectronID-HEEPV60"),
     eleIdVerbose = cms.bool(False)
     )
 


### PR DESCRIPTION
Content of this PR:
- Fix HEEP id name in config and add missing token inititalization
- Add new variable dEtaInSeed, which uses correctly the corresponding userfloat, also keep the original variable in case needed later
- Spotted a typo in the EGamma VID config for Loose ID, see [1]. Until it is fixed, a temporary recipe is provided (one have to simply rewrite the number in the corresponding python file after checkout).

[1] https://hypernews.cern.ch/HyperNews/CMS/get/egamma/1795.html
