### PR TITLE
Adding updateCollection to jets

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,14 @@ This is a development branch of the B2G EDMNtuples to be used for 2016 Data and 
  * Make a new CMSSW area:
 ```
 setenv SCRAM_ARCH slc6_amd64_gcc530 (or in bash: export SCRAM_ARCH=slc6_amd64_gcc530)
-cmsrel CMSSW_8_0_16
-cd CMSSW_8_0_16/src
+cmsrel CMSSW_8_0_20
+cd CMSSW_8_0_20/src
 cmsenv
 
 ```
  * Mirror for github
 ```
-setenv CMSSW_GIT_REFERENCE /cvmfs/cms.cern.ch/cmssw.git.daily
-
+setenv CMSSW_GIT_REFERENCE /cvmfs/cms.cern.ch/cmssw.git.daily  (this is not needed, it just boost your git clone)
 git cms-init
 
 ```
@@ -37,7 +36,7 @@ git cms-merge-topic -u cms-met:CMSSW_8_0_X-METFilterUpdate
  * Clone the github repository
 ```
 git clone git@github.com:cmsb2g/B2GAnaFW.git Analysis/B2GAnaFW -b CMSSW_8_0_X_V2
-git clone git@github.com:cms-jet/JetToolbox.git JMEAnalysis/JetToolbox -b jetToolbox_763
+git clone git@github.com:cms-jet/JetToolbox.git JMEAnalysis/JetToolbox -b jetToolbox_80X_V2
 ```
  * Compile
 ```

--- a/python/b2gedmntuples_cff.py
+++ b/python/b2gedmntuples_cff.py
@@ -1202,20 +1202,17 @@ subjetKeysAK8Puppi.jetLabel = cms.InputTag('selectedPatJetsAK8PFPuppiSoftDropPac
 genPart = copy.deepcopy(basic)
 genPart.variables += genPartVars
 genPart.prefix = cms.untracked.string("genPart")
-#genPart.src = cms.InputTag("filteredPrunedGenParticles")
 genPart.src = cms.InputTag("prunedGenParticles")
 
 ###genJetsAK8
 genJetsAK8 = copy.deepcopy(basic)
 genJetsAK8.prefix = cms.untracked.string("genJetsAK8")
-#genJetsAK8.src = cms.InputTag("ak8GenJetsNoNu")
 genJetsAK8.src = cms.InputTag("slimmedGenJetsAK8")
 
 ###genJetsAK8 soft drop
 genJetsAK8SoftDrop = copy.deepcopy(basic)
 genJetsAK8SoftDrop.prefix = cms.untracked.string("genJetsAK8SoftDrop")
 genJetsAK8SoftDrop.src = cms.InputTag("ak8GenJetsNoNuSoftDrop")
-#genJetsAK8.src = cms.InputTag("slimmedGenJetsAK8")
 
 ###genJetsAK8 subjets
 genJetsAK8SoftDropSubjets = copy.deepcopy(basic)

--- a/python/b2gedmntuples_cff.py
+++ b/python/b2gedmntuples_cff.py
@@ -657,15 +657,15 @@ jetToolboxAK8Vars = (
 #        ),
      cms.PSet(
         tag = cms.untracked.string("tau1"),
-        quantity = cms.untracked.string("userFloat('NjettinessAK8CHS:tau1')")
+        quantity = cms.untracked.string("userFloat('NjettinessAK8:tau1')")
         ),
      cms.PSet(
         tag = cms.untracked.string("tau2"),
-        quantity = cms.untracked.string("userFloat('NjettinessAK8CHS:tau2')")
+        quantity = cms.untracked.string("userFloat('NjettinessAK8:tau2')")
         ),
      cms.PSet(
         tag = cms.untracked.string("tau3"),
-        quantity = cms.untracked.string("userFloat('NjettinessAK8CHS:tau3')")
+        quantity = cms.untracked.string("userFloat('NjettinessAK8:tau3')")
         ),
      cms.PSet(
         tag = cms.untracked.string("softDropMass"),
@@ -1180,11 +1180,13 @@ jetKeysAK8Puppi = jetKeysAK8CHS.clone( jetLabel = 'boostedJetUserDataAK8Puppi' )
 ###subjetsAK8 with CHS		
 subjetsAK8CHS = copy.deepcopy(basic)		
 subjetsAK8CHS.variables += jetVars		
-subjetsAK8CHS.variables += jetToolboxAK8SubjetVars		
+#subjetsAK8CHS.variables += jetToolboxAK8SubjetVars		#### FIXME
 subjetsAK8CHS.prefix = cms.untracked.string("subjetAK8CHS")		
-subjetsAK8CHS.src = cms.InputTag("selectedPatJetsAK8PFCHSSoftDropPacked", "SubJets")		
+#subjetsAK8CHS.src = cms.InputTag("selectedPatJetsAK8PFCHSSoftDropPacked", "SubJets")		
+subjetsAK8CHS.src = cms.InputTag("slimmedJetsAK8PFCHSSoftDropPacked", "SubJets")		
 subjetKeysAK8CHS = copy.deepcopy( jetKeys )		
-subjetKeysAK8CHS.jetLabel = cms.InputTag("selectedPatJetsAK8PFCHSSoftDropPacked", "SubJets")
+#subjetKeysAK8CHS.jetLabel = cms.InputTag("selectedPatJetsAK8PFCHSSoftDropPacked", "SubJets")
+subjetKeysAK8CHS.jetLabel = cms.InputTag("slimmedJetsAK8PFCHSSoftDropPacked", "SubJets")
 
 ###subjetsAK8Puppi
 subjetsAK8Puppi = copy.deepcopy(basic)
@@ -1200,17 +1202,20 @@ subjetKeysAK8Puppi.jetLabel = cms.InputTag('selectedPatJetsAK8PFPuppiSoftDropPac
 genPart = copy.deepcopy(basic)
 genPart.variables += genPartVars
 genPart.prefix = cms.untracked.string("genPart")
-genPart.src = cms.InputTag("filteredPrunedGenParticles")
+#genPart.src = cms.InputTag("filteredPrunedGenParticles")
+genPart.src = cms.InputTag("prunedGenParticles")
 
 ###genJetsAK8
 genJetsAK8 = copy.deepcopy(basic)
 genJetsAK8.prefix = cms.untracked.string("genJetsAK8")
-genJetsAK8.src = cms.InputTag("ak8GenJetsNoNu")
+#genJetsAK8.src = cms.InputTag("ak8GenJetsNoNu")
+genJetsAK8.src = cms.InputTag("slimmedGenJetsAK8")
 
 ###genJetsAK8 soft drop
 genJetsAK8SoftDrop = copy.deepcopy(basic)
 genJetsAK8SoftDrop.prefix = cms.untracked.string("genJetsAK8SoftDrop")
 genJetsAK8SoftDrop.src = cms.InputTag("ak8GenJetsNoNuSoftDrop")
+#genJetsAK8.src = cms.InputTag("slimmedGenJetsAK8")
 
 ###genJetsAK8 subjets
 genJetsAK8SoftDropSubjets = copy.deepcopy(basic)

--- a/src/ElectronUserData.cc
+++ b/src/ElectronUserData.cc
@@ -63,11 +63,11 @@ private:
   int triggerBit;
   int debug_; 
   // ----------member data ---------------------------
-  edm::EDGetTokenT<edm::ValueMap<vid::CutFlowResult> > electronHEEPIdMapToken_;
   edm::EDGetTokenT<edm::ValueMap<vid::CutFlowResult> > eleVetoIdFullInfoMapToken_;
   edm::EDGetTokenT<edm::ValueMap<vid::CutFlowResult> > eleLooseIdFullInfoMapToken_;
   edm::EDGetTokenT<edm::ValueMap<vid::CutFlowResult> > eleMediumIdFullInfoMapToken_;
   edm::EDGetTokenT<edm::ValueMap<vid::CutFlowResult> > eleTightIdFullInfoMapToken_;
+  edm::EDGetTokenT<edm::ValueMap<vid::CutFlowResult> > electronHEEPIdMapToken_;
  
   bool verboseIdFlag_;
 
@@ -97,6 +97,7 @@ ElectronUserData::ElectronUserData(const edm::ParameterSet& iConfig):
    eleLooseIdFullInfoMapToken_(consumes<edm::ValueMap<vid::CutFlowResult> >(iConfig.getParameter<edm::InputTag>("eleLooseIdFullInfoMap"))),
    eleMediumIdFullInfoMapToken_(consumes<edm::ValueMap<vid::CutFlowResult> >(iConfig.getParameter<edm::InputTag>("eleMediumIdFullInfoMap"))),
    eleTightIdFullInfoMapToken_(consumes<edm::ValueMap<vid::CutFlowResult> >(iConfig.getParameter<edm::InputTag>("eleTightIdFullInfoMap"))),
+   electronHEEPIdMapToken_(consumes<edm::ValueMap<vid::CutFlowResult> >(iConfig.getParameter<edm::InputTag>("eleHEEPIdFullInfoMap"))),
    verboseIdFlag_(iConfig.getParameter<bool>("eleIdVerbose"))
 {
   debug_ = iConfig.getUntrackedParameter<int>("debugLevel",int(0));

--- a/test/b2gedmntuples_cfg.py
+++ b/test/b2gedmntuples_cfg.py
@@ -171,7 +171,7 @@ process.load('Configuration.StandardSequences.Services_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
 process.load("RecoEgamma/PhotonIdentification/PhotonIDValueMapProducer_cfi")
 process.load("RecoEgamma.ElectronIdentification.ElectronIDValueMapProducer_cfi")
-#process.load('RecoEgamma.ElectronIdentification.Identification.heepElectronID_HEEPV51_cff')
+#process.load('RecoEgamma.ElectronIdentification.Identification.heepElectronID_HEEPV60_cff')
 
 
 ### External JEC =====================================================================================================
@@ -651,7 +651,8 @@ process.electronUserData = cms.EDProducer(
     eleLooseIdFullInfoMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-loose"),
     eleMediumIdFullInfoMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-medium"),
     eleTightIdFullInfoMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-tight"),
-    eleHEEPIdIdFullInfoMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-HEEPV60"),
+    #eleHEEPIdFullInfoMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-HEEPV60"),
+    eleHEEPIdFullInfoMap = cms.InputTag("egmGsfElectronIDs:heepElectronID-HEEPV60"),
     eleIdVerbose = cms.bool(False)
     )
 

--- a/test/b2gedmntuples_cfg.py
+++ b/test/b2gedmntuples_cfg.py
@@ -32,13 +32,7 @@ import copy
 options = opts.VarParsing ('analysis')
 
 options.register('sample',
-#                 'file:00181849-176A-E511-8B11-848F69FD4C94.root',
-'/store/mc/RunIISpring16MiniAODv2/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14_ext3-v1/00000/0064B539-803A-E611-BDEA-002590D0B060.root',
-#'/store/mc/RunIISpring16MiniAODv2/TprimeBToTH_M-1800_LH_TuneCUETP8M1_13TeV-madgraph-pythia8/MINIAODSIM/PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/70000/E639441D-AD25-E611-93E2-B499BAABD482.root',
-    #'/store/mc/RunIISpring15MiniAODv2/TTJets_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2-v3/60000/00181849-176A-E511-8B11-848F69FD4C94.root', 
-     #'/store/mc/RunIIFall15MiniAODv2/QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8/MINIAODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1/10000/029802B3-83B8-E511-A002-0025905C22AE.root',
-     #'/store/mc/RunIIFall15MiniAODv2/TTJets_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1/00000/002253C9-DFB8-E511-8B0A-001A648F1C42.root',
-		 #'/store/data/Run2015D/JetHT/MINIAOD/16Dec2015-v1/00000/3085A2EF-6BB0-E511-87ED-0CC47A4D75EE.root',
+	'/store/mc/RunIISpring16MiniAODv2/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14_ext3-v1/00000/0064B539-803A-E611-BDEA-002590D0B060.root',
      opts.VarParsing.multiplicity.singleton,
      opts.VarParsing.varType.string,
      'Sample to analyze')
@@ -111,6 +105,8 @@ else:
   elif options.DataProcessing=="MC_MiniAODv2_80X_FastSim":
     options.globalTag="80X_mcRun2_asymptotic_2016_miniAODv2_v1"
     options.usePrivateSQLite = True
+  #elif options.DataProcessing=="MC_MiniAODv2_80X_":
+  # options.globalTag="80X_mcRun2_asymptotic_v4"
   elif options.DataProcessing=="Data_80X":
     options.globalTag="80X_dataRun2_Prompt_ICHEP16JEC_v0"
   else:
@@ -118,13 +114,16 @@ else:
 
 ###inputTag labels
 rhoLabel          	= "fixedGridRhoFastjetAll"
+jetAK4Label           	= 'slimmedJets'
+jetAK4LabelPuppi       	= 'slimmedJetsPuppi'
+jetAK8Label           	= 'slimmedJetsAK8'
 muLabel           	= 'slimmedMuons'
 elLabel           	= 'slimmedElectrons'
-phoLabel            = 'slimmedPhotons'
+phoLabel            	= 'slimmedPhotons'
 pvLabel           	= 'offlineSlimmedPrimaryVertices'
 convLabel         	= 'reducedEgamma:reducedConversions'
 particleFlowLabel 	= 'packedPFCandidates'    
-metLabel 		        = 'slimmedMETs'
+metLabel 	        = 'slimmedMETs'
 metNoHFLabel 	     	= 'slimmedMETsNoHF'
 
 triggerResultsLabel 	  = "TriggerResults"
@@ -157,6 +156,8 @@ process.source = cms.Source("PoolSource",
       options.sample
       )
     )
+#from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValTTbarPileUpMINIAODSIM
+#process.source.fileNames = filesRelValTTbarPileUpMINIAODSIM
 ### Setting global tag 
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
 from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag
@@ -344,6 +345,7 @@ if options.usePrivateSQLiteForJER:
 ### Puppi
 ### (https://twiki.cern.ch/twiki/bin/viewauth/CMS/PUPPI)
 ### ------------------------------------------------------------------
+'''
 process.load('CommonTools/PileupAlgos/Puppi_cff')
 process.puppi.candName = cms.InputTag('packedPFCandidates')
 process.puppi.vertexName = cms.InputTag('offlineSlimmedPrimaryVertices')
@@ -352,6 +354,7 @@ process.puppi.useExistingWeights = cms.bool(True)
 #process.puppiOnTheFly = process.puppi.clone()
 
 #process.puppiOnTheFly.useExistingWeights = True
+'''
 
 ### ------------------------------------------------------------------
 ### Recluster jets and adding subtructure tools from jetToolbox 
@@ -380,18 +383,6 @@ listBtagDiscriminatorsAK8 = [
 
 runMC = ("MC" in options.DataProcessing)
 
-ak4Cut='pt > 25 && abs(eta) < 5.'
-ak8Cut='pt > 200 && abs(eta) < 2.4'
-jetToolbox( process, 'ak4', 'analysisPath', 'edmNtuplesOut', runOnMC=runMC, addQGTagger=True, bTagInfos=listBTagInfos, bTagDiscriminators=listBtagDiscriminatorsAK4, Cut=ak4Cut )
-jetToolbox( process, 'ak4', 'analysisPath', 'edmNtuplesOut', runOnMC=runMC, PUMethod='Puppi', newPFCollection=True, nameNewPFCollection='puppi', bTagInfos=listBTagInfos, bTagDiscriminators=listBtagDiscriminatorsAK4, Cut=ak4Cut )
-jetToolbox( process, 'ak8', 'analysisPath', 'edmNtuplesOut', runOnMC=runMC, addSoftDropSubjets=True, addTrimming=True, rFiltTrim=0.1, addPruning=True, addFiltering=True, addSoftDrop=True, addNsub=True, bTagInfos=listBTagInfos, bTagDiscriminators=listBtagDiscriminatorsAK8, addCMSTopTagger=True, Cut=ak8Cut , addNsubSubjets=True, subjetMaxTau=4 )
-jetToolbox( process, 'ak8', 'analysisPath', 'edmNtuplesOut', runOnMC=runMC, PUMethod='Puppi', newPFCollection=True, nameNewPFCollection='puppi', addSoftDropSubjets=True, addTrimming=True, addPruning=True, addFiltering=True, addSoftDrop=True, addNsub=True, bTagInfos=listBTagInfos, bTagDiscriminators=listBtagDiscriminatorsAK8, addCMSTopTagger=True, Cut=ak8Cut, addNsubSubjets=True, subjetMaxTau=4 )
-# Added , addNsubSubjets=True, subjetMaxTau=4  to both ak8 above
-
-jLabel		= 'selectedPatJetsAK4PFCHS'
-jLabelAK8	= 'selectedPatJetsAK8PFCHS'
-jLabelPuppi	= 'selectedPatJetsAK4PFPuppi'
-jLabelAK8Puppi 	= 'selectedPatJetsAK8PFPuppi'
 
 # JER Twiki:
 #   https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookJetEnergyResolution#Scale_factors
@@ -402,6 +393,25 @@ jetAlgoPuppi    = 'AK4PFPuppi'
 jetAlgoAK8      = 'AK8PFchs'
 jetAlgoAK8Puppi = 'AK8PFPuppi'
 
+ak4Cut='pt > 25 && abs(eta) < 5.'
+ak8Cut='pt > 200 && abs(eta) < 2.4'
+jetToolbox( process, 'ak4', 'analysisPath', 'edmNtuplesOut', runOnMC=runMC, updateCollection=jetAK4Label, JETCorrPayload=jetAlgo, JETCorrLevels=corrections, addQGTagger=True ) 
+jetToolbox( process, 'ak4', 'analysisPath', 'edmNtuplesOut', runOnMC=runMC, updateCollection=jetAK4LabelPuppi, JETCorrPayload='AK4PFPuppi', JETCorrLevels=['L2Relative', 'L3Absolute'] )  
+jetToolbox( process, 'ak8', 'analysisPath', 'edmNtuplesOut', runOnMC=runMC, updateCollection=jetAK8Label, JETCorrPayload=jetAlgoAK8, addTrimming=True, rFiltTrim=0.1, addFiltering=True ) #, addSoftDropSubjets=True, addPruning=True, addSoftDrop=True, addCMSTopTagger=True , addNsubSubjets=True, subjetMaxTau=4 ) #, addNsub=True, bTagInfos=listBTagInfos, bTagDiscriminators=listBtagDiscriminatorsAK8, Cut=ak8Cut
+jetToolbox( process, 'ak8', 'analysisPath', 'edmNtuplesOut', runOnMC=runMC, PUMethod='Puppi', addSoftDropSubjets=True, addTrimming=True, addPruning=True, addFiltering=True, addSoftDrop=True, addNsub=True, bTagInfos=listBTagInfos, bTagDiscriminators=listBtagDiscriminatorsAK8, Cut=ak8Cut, addNsubSubjets=True, subjetMaxTau=4 )
+
+''' Leave it there until last tests
+#jetToolbox( process, 'ak4', 'analysisPath', 'edmNtuplesOut', runOnMC=runMC, addQGTagger=True, JETCorrPayload=jetAlgo, JETCorrLevels=corrections, bTagInfos=listBTagInfos, bTagDiscriminators=listBtagDiscriminatorsAK4, Cut=ak4Cut )
+#jetToolbox( process, 'ak4', 'analysisPath', 'edmNtuplesOut', runOnMC=runMC, PUMethod='Puppi', newPFCollection=True, nameNewPFCollection='puppi', bTagInfos=listBTagInfos, bTagDiscriminators=listBtagDiscriminatorsAK4, Cut=ak4Cut )
+#jetToolbox( process, 'ak8', 'analysisPath', 'edmNtuplesOut', runOnMC=runMC, addSoftDropSubjets=True, addTrimming=True, rFiltTrim=0.1, addPruning=True, addFiltering=True, addSoftDrop=True, addNsub=True, bTagInfos=listBTagInfos, bTagDiscriminators=listBtagDiscriminatorsAK8, addCMSTopTagger=True, Cut=ak8Cut , addNsubSubjets=True, subjetMaxTau=4 )
+#jetToolbox( process, 'ak8', 'analysisPath', 'edmNtuplesOut', runOnMC=runMC, PUMethod='Puppi', newPFCollection=True, nameNewPFCollection='puppi', addSoftDropSubjets=True, addTrimming=True, addPruning=True, addFiltering=True, addSoftDrop=True, addNsub=True, bTagInfos=listBTagInfos, bTagDiscriminators=listBtagDiscriminatorsAK8, addCMSTopTagger=True, Cut=ak8Cut, addNsubSubjets=True, subjetMaxTau=4 )
+# Added , addNsubSubjets=True, subjetMaxTau=4  to both ak8 above
+'''
+
+jLabel		= 'selectedPatJetsAK4PFCHS'
+jLabelAK8	= 'selectedPatJetsAK8PFCHS'
+jLabelPuppi	= 'selectedPatJetsAK4PFPuppi'
+jLabelAK8Puppi 	= 'selectedPatJetsAK8PFPuppi'
 
 ### ---------------------------------------------------------------------------
 ### Removing the HF from the MET computation as from 7 Aug 2015 recommendations
@@ -479,7 +489,7 @@ process.BadChargedCandidateFilter.PFCandidates = cms.InputTag("packedPFCandidate
 ### Selected leptons and jets
 
 ### Check PackedCandidate vertex to make sure there is one
-process.chs.cut = 'vertexRef.isNonnull() && fromPV()'
+#process.chs.cut = 'vertexRef.isNonnull() && fromPV()'  #### TEST
 
 process.skimmedPatMuons = cms.EDFilter(
     "PATMuonSelector",
@@ -598,7 +608,8 @@ process.boostedJetUserDataAK8 = cms.EDProducer(
     'BoostedJetToolboxUserData',
     jetLabel  = cms.InputTag('jetUserDataAK8'),
     #topjetLabel = cms.InputTag('patJetsCMSTopTagCHSPacked'),
-    vjetLabel = cms.InputTag('selectedPatJetsAK8PFCHSSoftDropPacked'),
+    #vjetLabel = cms.InputTag('selectedPatJetsAK8PFCHSSoftDropPacked'),  ### TEST
+    vjetLabel = cms.InputTag('slimmedJetsAK8PFCHSSoftDropPacked', 'SubJets'),
     distMax = cms.double(0.8)
 )
 
@@ -631,7 +642,8 @@ process.boostedJetUserDataAK8Puppi = cms.EDProducer(
     'BoostedJetToolboxUserData',
     jetLabel  = cms.InputTag('jetUserDataAK8Puppi'),
     #topjetLabel = cms.InputTag('patJetsCMSTopTagPuppiPacked'),
-    vjetLabel = cms.InputTag('selectedPatJetsAK8PFPuppiSoftDropPacked'),
+    #vjetLabel = cms.InputTag('selectedPatJetsAK8PFPuppiSoftDropPacked'),  ### TEST
+    vjetLabel = cms.InputTag('slimmedJetsAK8PFPuppiSoftDropPacked', 'SubJets'),
     distMax = cms.double(0.8)
     )
 

--- a/test/b2gedmntuples_cfg.py
+++ b/test/b2gedmntuples_cfg.py
@@ -393,20 +393,11 @@ jetAlgoPuppi    = 'AK4PFPuppi'
 jetAlgoAK8      = 'AK8PFchs'
 jetAlgoAK8Puppi = 'AK8PFPuppi'
 
-ak4Cut='pt > 25 && abs(eta) < 5.'
-ak8Cut='pt > 200 && abs(eta) < 2.4'
+ak8Cut='pt > 170 && abs(eta) < 2.4'
 jetToolbox( process, 'ak4', 'analysisPath', 'edmNtuplesOut', runOnMC=runMC, updateCollection=jetAK4Label, JETCorrPayload=jetAlgo, JETCorrLevels=corrections, addQGTagger=True ) 
 jetToolbox( process, 'ak4', 'analysisPath', 'edmNtuplesOut', runOnMC=runMC, updateCollection=jetAK4LabelPuppi, JETCorrPayload='AK4PFPuppi', JETCorrLevels=['L2Relative', 'L3Absolute'] )  
 jetToolbox( process, 'ak8', 'analysisPath', 'edmNtuplesOut', runOnMC=runMC, updateCollection=jetAK8Label, JETCorrPayload=jetAlgoAK8, addTrimming=True, rFiltTrim=0.1, addFiltering=True ) #, addSoftDropSubjets=True, addPruning=True, addSoftDrop=True, addCMSTopTagger=True , addNsubSubjets=True, subjetMaxTau=4 ) #, addNsub=True, bTagInfos=listBTagInfos, bTagDiscriminators=listBtagDiscriminatorsAK8, Cut=ak8Cut
 jetToolbox( process, 'ak8', 'analysisPath', 'edmNtuplesOut', runOnMC=runMC, PUMethod='Puppi', addSoftDropSubjets=True, addTrimming=True, addPruning=True, addFiltering=True, addSoftDrop=True, addNsub=True, bTagInfos=listBTagInfos, bTagDiscriminators=listBtagDiscriminatorsAK8, Cut=ak8Cut, addNsubSubjets=True, subjetMaxTau=4 )
-
-''' Leave it there until last tests
-#jetToolbox( process, 'ak4', 'analysisPath', 'edmNtuplesOut', runOnMC=runMC, addQGTagger=True, JETCorrPayload=jetAlgo, JETCorrLevels=corrections, bTagInfos=listBTagInfos, bTagDiscriminators=listBtagDiscriminatorsAK4, Cut=ak4Cut )
-#jetToolbox( process, 'ak4', 'analysisPath', 'edmNtuplesOut', runOnMC=runMC, PUMethod='Puppi', newPFCollection=True, nameNewPFCollection='puppi', bTagInfos=listBTagInfos, bTagDiscriminators=listBtagDiscriminatorsAK4, Cut=ak4Cut )
-#jetToolbox( process, 'ak8', 'analysisPath', 'edmNtuplesOut', runOnMC=runMC, addSoftDropSubjets=True, addTrimming=True, rFiltTrim=0.1, addPruning=True, addFiltering=True, addSoftDrop=True, addNsub=True, bTagInfos=listBTagInfos, bTagDiscriminators=listBtagDiscriminatorsAK8, addCMSTopTagger=True, Cut=ak8Cut , addNsubSubjets=True, subjetMaxTau=4 )
-#jetToolbox( process, 'ak8', 'analysisPath', 'edmNtuplesOut', runOnMC=runMC, PUMethod='Puppi', newPFCollection=True, nameNewPFCollection='puppi', addSoftDropSubjets=True, addTrimming=True, addPruning=True, addFiltering=True, addSoftDrop=True, addNsub=True, bTagInfos=listBTagInfos, bTagDiscriminators=listBtagDiscriminatorsAK8, addCMSTopTagger=True, Cut=ak8Cut, addNsubSubjets=True, subjetMaxTau=4 )
-# Added , addNsubSubjets=True, subjetMaxTau=4  to both ak8 above
-'''
 
 jLabel		= 'selectedPatJetsAK4PFCHS'
 jLabelAK8	= 'selectedPatJetsAK8PFCHS'
@@ -487,10 +478,6 @@ process.BadChargedCandidateFilter.PFCandidates = cms.InputTag("packedPFCandidate
 ### ------------------------------------------------------------------
 
 ### Selected leptons and jets
-
-### Check PackedCandidate vertex to make sure there is one
-#process.chs.cut = 'vertexRef.isNonnull() && fromPV()'  #### TEST
-
 process.skimmedPatMuons = cms.EDFilter(
     "PATMuonSelector",
     src = cms.InputTag(muLabel),
@@ -608,7 +595,6 @@ process.boostedJetUserDataAK8 = cms.EDProducer(
     'BoostedJetToolboxUserData',
     jetLabel  = cms.InputTag('jetUserDataAK8'),
     #topjetLabel = cms.InputTag('patJetsCMSTopTagCHSPacked'),
-    #vjetLabel = cms.InputTag('selectedPatJetsAK8PFCHSSoftDropPacked'),  ### TEST
     vjetLabel = cms.InputTag('slimmedJetsAK8PFCHSSoftDropPacked', 'SubJets'),
     distMax = cms.double(0.8)
 )
@@ -642,7 +628,6 @@ process.boostedJetUserDataAK8Puppi = cms.EDProducer(
     'BoostedJetToolboxUserData',
     jetLabel  = cms.InputTag('jetUserDataAK8Puppi'),
     #topjetLabel = cms.InputTag('patJetsCMSTopTagPuppiPacked'),
-    #vjetLabel = cms.InputTag('selectedPatJetsAK8PFPuppiSoftDropPacked'),  ### TEST
     vjetLabel = cms.InputTag('slimmedJetsAK8PFPuppiSoftDropPacked', 'SubJets'),
     distMax = cms.double(0.8)
     )


### PR DESCRIPTION
- Using updateCollection from jetToolbox to use jet collections from miniAOD (slimmedJets, slimmedJetsPuppi, slimmedJetsAK8) and avoid reclustering.
- Although this PR improves a lot the framework, it needs some more work.
- This version is good for test
