### PR TITLE
Fix stochastic part of JER smearing

### DIFF
--- a/src/JetUserData.cc
+++ b/src/JetUserData.cc
@@ -250,7 +250,7 @@ void JetUserData::produce( edm::Event& iEvent, const edm::EventSetup& iSetup) {
       }
       // ... and gaussian smear the rest
       if (!isGenMatched && JERSF>1) {
-	double sigma = std::sqrt(JERSF * JERSF - 1) * PtResolution / jet.p4();
+	double sigma = std::sqrt(JERSF * JERSF - 1) * PtResolution / jet.pt();
 	smearedP4 *= 1 + rnd_.Gaus(0, sigma);
       }
     }

--- a/src/JetUserData.cc
+++ b/src/JetUserData.cc
@@ -250,7 +250,7 @@ void JetUserData::produce( edm::Event& iEvent, const edm::EventSetup& iSetup) {
       }
       // ... and gaussian smear the rest
       if (!isGenMatched && JERSF>1) {
-	double sigma = std::sqrt(JERSF * JERSF - 1) * PtResolution;
+	double sigma = std::sqrt(JERSF * JERSF - 1) * PtResolution / jet.p4();
 	smearedP4 *= 1 + rnd_.Gaus(0, sigma);
       }
     }


### PR DESCRIPTION
Found a bug for jets not well matched to gen jets in the smearing procedure (stochastic part of the smearing).
https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetResolution#Smearing_procedures
The twiki contains: relative pt resolution, but the absolute value was used previously.
