### PR TITLE
Add ele MVA IDs, fix uncorrSDMass

### DIFF
--- a/python/b2gedmntuples_cff.py
+++ b/python/b2gedmntuples_cff.py
@@ -746,9 +746,18 @@ jetToolboxAK8Vars = (
         tag = cms.untracked.string("tau3Puppi"),
         quantity = cms.untracked.string("userFloat('ak8PFJetsPuppiValueMap:NjettinessAK8PuppiTau3')")
         ),
+     # Uncorrected SD mass used for W tagging (needs additional W specific GEN/RECO corrections)
+     # https://twiki.cern.ch/twiki/bin/view/CMS/JetWtagging?rev=54#Working_points_and_scale_factors
+     # --> https://github.com/cms-jet/PuppiSoftdropMassCorr/#get-uncorrected-puppi-soft-drop-mass-from-miniaod
      cms.PSet(
-        tag = cms.untracked.string("uncorrSDMassAK8Puppi"),
-        quantity = cms.untracked.string("? hasUserFloat('subjetSumMassSoftDropPuppi') ? userFloat('subjetSumMassSoftDropPuppi') : -999 ")
+        tag = cms.untracked.string("uncorrSDMassPuppi"),
+        quantity = cms.untracked.string("? hasUserFloat('uncorrSDMassPuppi') ? userFloat('uncorrSDMassPuppi') : -999 ")
+        ),
+     # Corrected (L1L2L3 applied on subjets) SD mass used for top tagging
+     # https://twiki.cern.ch/twiki/bin/view/CMS/JetTopTagging?rev=14#13_TeV_working_points_CMSSW_8_0
+     cms.PSet(
+        tag = cms.untracked.string("corrSDMassPuppi"),
+        quantity = cms.untracked.string("? hasUserFloat('corrSDMassPuppi') ? userFloat('corrSDMassPuppi') : -999 ")
         ),
 )
 

--- a/python/b2gedmntuples_cff.py
+++ b/python/b2gedmntuples_cff.py
@@ -1042,6 +1042,22 @@ electronVars = (
         tag = cms.untracked.string("vidHEEPnoiso"),
         quantity = cms.untracked.string("userFloat('vidHEEPnoiso')")
         ),
+    cms.PSet(
+        tag = cms.untracked.string("vidMvaGPvalue"),
+        quantity = cms.untracked.string("userFloat('vidMvaGPvalue')")
+        ),
+    cms.PSet(
+        tag = cms.untracked.string("vidMvaGPcateg"),
+        quantity = cms.untracked.string("userInt('vidMvaGPcateg')")
+        ),
+    cms.PSet(
+        tag = cms.untracked.string("vidMvaHZZvalue"),
+        quantity = cms.untracked.string("userFloat('vidMvaHZZvalue')")
+        ),
+    cms.PSet(
+        tag = cms.untracked.string("vidMvaHZZcateg"),
+        quantity = cms.untracked.string("userInt('vidMvaHZZcateg')")
+        ),
     )
 
 

--- a/src/BoostedJetToolboxUserData.cc
+++ b/src/BoostedJetToolboxUserData.cc
@@ -83,22 +83,27 @@ void BoostedJetToolboxUserData::produce( edm::Event& iEvent, const edm::EventSet
 
 		pat::Jet & jet = (*jetColl)[i];
 
-		float min_dR = 9999, uncorrSDMass = -9999;
+		float min_dR = 999, uncorrSDMass = -999, corrSDMass = -999;
 		for ( auto const & puppiSDJet : *puppiSDjetHandle ) {
 
 			float temp_dR = reco::deltaR(jet.eta(),jet.phi(),puppiSDJet.eta(),puppiSDJet.phi());
 			if ( temp_dR < distMax_ && temp_dR < min_dR ) {
 				min_dR = temp_dR;
 				TLorentzVector puppi_softdrop, puppi_softdrop_subjet;
+				TLorentzVector puppi_softdrop_corr, puppi_softdrop_subjet_corr;
 				auto const & sbSubjetsPuppi = puppiSDJet.subjets("SoftDropPuppi");
 				for ( auto const & it : sbSubjetsPuppi ) {
 					puppi_softdrop_subjet.SetPtEtaPhiM(it->correctedP4(0).pt(),it->correctedP4(0).eta(),it->correctedP4(0).phi(),it->correctedP4(0).mass());
 					puppi_softdrop+=puppi_softdrop_subjet;
+					puppi_softdrop_subjet_corr.SetPtEtaPhiM(it->pt(),it->eta(),it->phi(),it->mass());
+					puppi_softdrop_corr+=puppi_softdrop_subjet_corr;
 				}
 				uncorrSDMass = puppi_softdrop.M();
+				corrSDMass   = puppi_softdrop_corr.M();
 			}
 		}
-		jet.addUserFloat("subjetSumMassSoftDropPuppi", uncorrSDMass );
+		jet.addUserFloat("uncorrSDMassPuppi", uncorrSDMass );
+		jet.addUserFloat("corrSDMassPuppi",   corrSDMass );
 
 
 		for ( auto const & jetWithSubjet : *jetWithSubjetHandle ) {

--- a/src/BoostedJetToolboxUserData.cc
+++ b/src/BoostedJetToolboxUserData.cc
@@ -83,20 +83,22 @@ void BoostedJetToolboxUserData::produce( edm::Event& iEvent, const edm::EventSet
 
 		pat::Jet & jet = (*jetColl)[i];
 
+		float min_dR = 9999, uncorrSDMass = -9999;
 		for ( auto const & puppiSDJet : *puppiSDjetHandle ) {
 
-			float temp_dR2 = reco::deltaR2(jet.eta(),jet.phi(),puppiSDJet.eta(),puppiSDJet.phi());
-			if ( temp_dR2 < distMax_ ) {
-
+			float temp_dR = reco::deltaR(jet.eta(),jet.phi(),puppiSDJet.eta(),puppiSDJet.phi());
+			if ( temp_dR < distMax_ && temp_dR < min_dR ) {
+				min_dR = temp_dR;
 				TLorentzVector puppi_softdrop, puppi_softdrop_subjet;
-				auto const & sbSubjetsPuppi = puppiSDJet.subjets("SoftDrop");
+				auto const & sbSubjetsPuppi = puppiSDJet.subjets("SoftDropPuppi");
 				for ( auto const & it : sbSubjetsPuppi ) {
-					puppi_softdrop_subjet.SetPtEtaPhiM(it->pt(),it->eta(),it->phi(),it->mass());
+					puppi_softdrop_subjet.SetPtEtaPhiM(it->correctedP4(0).pt(),it->correctedP4(0).eta(),it->correctedP4(0).phi(),it->correctedP4(0).mass());
 					puppi_softdrop+=puppi_softdrop_subjet;
 				}
-				jet.addUserFloat("subjetSumMassSoftDropPuppi", puppi_softdrop.M() );
+				uncorrSDMass = puppi_softdrop.M();
 			}
 		}
+		jet.addUserFloat("subjetSumMassSoftDropPuppi", uncorrSDMass );
 
 
 		for ( auto const & jetWithSubjet : *jetWithSubjetHandle ) {

--- a/src/ElectronUserData.cc
+++ b/src/ElectronUserData.cc
@@ -68,7 +68,10 @@ private:
   edm::EDGetTokenT<edm::ValueMap<vid::CutFlowResult> > eleMediumIdFullInfoMapToken_;
   edm::EDGetTokenT<edm::ValueMap<vid::CutFlowResult> > eleTightIdFullInfoMapToken_;
   edm::EDGetTokenT<edm::ValueMap<vid::CutFlowResult> > electronHEEPIdMapToken_;
-  edm::EDGetTokenT<edm::ValueMap<float> > electronMVAIdMapToken_;
+  edm::EDGetTokenT<edm::ValueMap<float> > electronGPMvaValueMapToken_;
+  edm::EDGetTokenT<edm::ValueMap<int>  > electronGPMvaCatMapToken_;
+  edm::EDGetTokenT<edm::ValueMap<float> > electronHZZMvaValueMapToken_;
+  edm::EDGetTokenT<edm::ValueMap<int> > electronHZZMvaCatMapToken_;
  
   bool verboseIdFlag_;
 
@@ -99,7 +102,10 @@ ElectronUserData::ElectronUserData(const edm::ParameterSet& iConfig):
    eleMediumIdFullInfoMapToken_(consumes<edm::ValueMap<vid::CutFlowResult> >(iConfig.getParameter<edm::InputTag>("eleMediumIdFullInfoMap"))),
    eleTightIdFullInfoMapToken_(consumes<edm::ValueMap<vid::CutFlowResult> >(iConfig.getParameter<edm::InputTag>("eleTightIdFullInfoMap"))),
    electronHEEPIdMapToken_(consumes<edm::ValueMap<vid::CutFlowResult> >(iConfig.getParameter<edm::InputTag>("eleHEEPIdFullInfoMap"))),
-   electronMVAIdMapToken_(consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("eleMVAIdValue"))),
+   electronGPMvaValueMapToken_(consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("eleGPMvaValueMap"))),
+   electronGPMvaCatMapToken_(consumes<edm::ValueMap<int>   >(iConfig.getParameter<edm::InputTag>("eleGPMvaCatMap"))),
+   electronHZZMvaValueMapToken_(consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("eleHZZMvaValueMap"))),
+   electronHZZMvaCatMapToken_(consumes<edm::ValueMap<int> >(iConfig.getParameter<edm::InputTag>("eleHZZMvaCatMap"))),
    verboseIdFlag_(iConfig.getParameter<bool>("eleIdVerbose"))
 {
   debug_ = iConfig.getUntrackedParameter<int>("debugLevel",int(0));
@@ -156,12 +162,19 @@ void ElectronUserData::produce( edm::Event& iEvent, const edm::EventSetup& iSetu
   edm::Handle<edm::ValueMap<vid::CutFlowResult> > tight_id_cutflow_data;
   edm::Handle<edm::ValueMap<vid::CutFlowResult> > heep_id_cutflow_data;
   edm::Handle<edm::ValueMap<float> > mva_id_data;
-  iEvent.getByToken(eleVetoIdFullInfoMapToken_,veto_id_cutflow_data);
+  edm::Handle<edm::ValueMap<float> > GPMva_values;
+  edm::Handle<edm::ValueMap<int> >   GPMva_cats;
+  edm::Handle<edm::ValueMap<float> > HZZMva_values;
+  edm::Handle<edm::ValueMap<int> >   HZZMva_cats;
+   iEvent.getByToken(eleVetoIdFullInfoMapToken_,veto_id_cutflow_data);
   iEvent.getByToken(eleLooseIdFullInfoMapToken_,loose_id_cutflow_data);
   iEvent.getByToken(eleMediumIdFullInfoMapToken_,medium_id_cutflow_data);
   iEvent.getByToken(eleTightIdFullInfoMapToken_,tight_id_cutflow_data);
   iEvent.getByToken(electronHEEPIdMapToken_,heep_id_cutflow_data);
-  iEvent.getByToken(electronMVAIdMapToken_,mva_id_data);
+  iEvent.getByToken(electronGPMvaValueMapToken_,  GPMva_values);
+  iEvent.getByToken(electronGPMvaCatMapToken_,    GPMva_cats);
+  iEvent.getByToken(electronHZZMvaValueMapToken_, HZZMva_values);
+  iEvent.getByToken(electronHZZMvaCatMapToken_,   HZZMva_cats);
   //passVetoId_.clear();     
   //passTightId_.clear();
 
@@ -268,8 +281,11 @@ void ElectronUserData::produce( edm::Event& iEvent, const edm::EventSetup& iSetu
     bool vidTight = (*tight_id_cutflow_data)[ elPtr ].cutFlowPassed();
     bool vidHEEP  = (*heep_id_cutflow_data)[ elPtr ].cutFlowPassed();
     
-    float mvaval = (*mva_id_data)[ elPtr ]; 
-    // if(mvaval > 0.1 ) cout<<"true ele "<<mvaval<<endl;
+    float gp_mva_val  = (*GPMva_values)[ elPtr ];
+    int   gp_mva_cat  = (*GPMva_cats)[ elPtr ];
+    float hzz_mva_val = (*HZZMva_values)[ elPtr ];
+    int   hzz_mva_cat = (*HZZMva_cats)[ elPtr ];
+    // if(gp_mva_val > 0.1 ) cout<<"true ele "<<mvaval<<endl;
 
 
 
@@ -334,7 +350,10 @@ void ElectronUserData::produce( edm::Event& iEvent, const edm::EventSetup& iSetu
     el.addUserFloat("vidMediumnoiso",    vidMedium_noiso );
     el.addUserFloat("vidTightnoiso",    vidTight_noiso );
     el.addUserFloat("vidHEEPnoiso",    vidHEEP_noiso );
-    el.addUserFloat("mvaIDvalue", mvaval);
+    el.addUserFloat("vidMvaGPvalue",  gp_mva_val);
+    el.addUserInt  ("vidMvaGPcateg",  gp_mva_cat);
+    el.addUserFloat("vidMvaHZZvalue", hzz_mva_val);
+    el.addUserInt  ("vidMvaHZZcateg", hzz_mva_cat);
   }
 
   iEvent.put( eleColl );

--- a/test/b2gedmntuples_cfg.py
+++ b/test/b2gedmntuples_cfg.py
@@ -768,7 +768,7 @@ process.photonJetsUserData = cms.EDProducer(
 process.boostedJetUserDataAK8 = cms.EDProducer(
     'BoostedJetToolboxUserData',
     jetLabel  = cms.InputTag('jetUserDataAK8'),
-    puppiSDjetLabel = cms.InputTag('packedPatJetsAK8PFPuppiSoftDrop'),
+    puppiSDjetLabel = cms.InputTag('slimmedJetsAK8'),
     jetWithSubjetLabel = cms.InputTag('selectedPatJetsAK8PFCHSSoftDropPacked'),
     distMax = cms.double(0.8)
 )
@@ -823,7 +823,10 @@ process.electronUserData = cms.EDProducer(
     eleMediumIdFullInfoMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-medium"),
     eleTightIdFullInfoMap = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-tight"),
     eleHEEPIdFullInfoMap = cms.InputTag("egmGsfElectronIDs:heepElectronID-HEEPV60"),
-    eleMVAIdValue = cms.InputTag("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring16GeneralPurposeV1Values"),
+    eleGPMvaValueMap    = cms.InputTag("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring16GeneralPurposeV1Values"),
+    eleGPMvaCatMap      = cms.InputTag("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring16GeneralPurposeV1Categories"),
+    eleHZZMvaValueMap   = cms.InputTag("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring16HZZV1Values"),
+    eleHZZMvaCatMap     = cms.InputTag("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring16HZZV1Categories"),
     eleIdVerbose = cms.bool(False)
     )
 

--- a/test/b2gedmntuples_cfg.py
+++ b/test/b2gedmntuples_cfg.py
@@ -801,7 +801,7 @@ if "FastSim" in options.DataProcessing:
 process.boostedJetUserDataAK8Puppi = cms.EDProducer(
     'BoostedJetToolboxUserData',
     jetLabel  = cms.InputTag('jetUserDataAK8Puppi'),
-    puppiSDjetLabel = cms.InputTag('packedPatJetsAK8PFPuppiSoftDrop'),
+    puppiSDjetLabel = cms.InputTag('slimmedJetsAK8'),
     jetWithSubjetLabel = cms.InputTag('selectedPatJetsAK8PFPuppiSoftDropPacked'),
     distMax = cms.double(0.8)
     )

--- a/test/b2gedmntuples_cfg.py
+++ b/test/b2gedmntuples_cfg.py
@@ -768,7 +768,7 @@ process.photonJetsUserData = cms.EDProducer(
 process.boostedJetUserDataAK8 = cms.EDProducer(
     'BoostedJetToolboxUserData',
     jetLabel  = cms.InputTag('jetUserDataAK8'),
-    puppiSDjetLabel = cms.InputTag('slimmedJetsAK8'),
+    puppiSDjetLabel = cms.InputTag('packedPatJetsAK8PFPuppiSoftDrop'),
     jetWithSubjetLabel = cms.InputTag('selectedPatJetsAK8PFCHSSoftDropPacked'),
     distMax = cms.double(0.8)
 )
@@ -801,7 +801,7 @@ if "FastSim" in options.DataProcessing:
 process.boostedJetUserDataAK8Puppi = cms.EDProducer(
     'BoostedJetToolboxUserData',
     jetLabel  = cms.InputTag('jetUserDataAK8Puppi'),
-    puppiSDjetLabel = cms.InputTag('slimmedJetsAK8'),
+    puppiSDjetLabel = cms.InputTag('packedPatJetsAK8PFPuppiSoftDrop'),
     jetWithSubjetLabel = cms.InputTag('selectedPatJetsAK8PFPuppiSoftDropPacked'),
     distMax = cms.double(0.8)
     )

--- a/test/b2gedmntuples_cfg.py
+++ b/test/b2gedmntuples_cfg.py
@@ -130,7 +130,7 @@ if options.globalTag != "":
   print "!!!!WARNING: You have chosen globalTag as", options.globalTag, ". Please check if this corresponds to your dataset."
 else: 
   if options.DataProcessing=="Data_80X_Run2016H_03Feb2017":
-    options.globalTag="80X_dataRun2_Prompt_v15"
+    options.globalTag="80X_dataRun2_Prompt_v16"
   elif options.DataProcessing in [
         'Data_80X_Run2016BCD_03Feb2017', 
         'Data_80X_Run2016EF_03Feb2017', 
@@ -239,7 +239,7 @@ if options.usePrivateSQLite:
       iovStart = 278802
       iovEnd   = 280385
     elif options.DataProcessing=="MC_MiniAODv2_80X_Summer16":
-      jec_era = "Summer16_03Feb2017V4_MC" 
+      jec_era = "Summer16_23Sep2016V4_MC" 
     elif options.DataProcessing=="MC_MiniAODv2_80X_FastSim":
       jec_era = "Spring16_25nsFastSimMC_V1" 
     else: 

--- a/test/b2gedmntuples_cfg.py
+++ b/test/b2gedmntuples_cfg.py
@@ -172,7 +172,7 @@ triggerResultsLabel 	 = "TriggerResults"
 triggerSummaryLabel 	 = "hltTriggerSummaryAOD"
 hltElectronFilterLabel = "hltL1sL1Mu3p5EG12ORL1MuOpenEG12L3Filtered8"
 
-if "MC" in options.DataProcessing: 
+if "MC" in options.DataProcessing or "03Feb2017" in options.DataProcessing:
   metProcess = "PAT"
 else:
   metProcess = "RECO"


### PR DESCRIPTION
Contents of this PR:
- Add general purpose (tight) and HZZ (very loose) electron MVA values/categories
- Fix an issue with uncorrected AK8 Puppi SoftDrop mass used for W tagging [1]
  * Match by closest distance with the MINIAOD AK8 collection, use subjets("SoftDropPuppi")
  * Use correctedP4(0) of subjets, to exactly match recipe [2]
- Add corrected Puppi SD mass, recommended for top tagging [3]
  * Computed from the same "SoftDropPuppi" subjets, but with L1L2L3 corrections applied
- Modify TriggerResults process to "PAT" in order to access latest filters in ReMiniAOD [4]
- Fix JEC era name for MC, Update Run2016H GT

[1] - https://twiki.cern.ch/twiki/bin/view/CMS/JetWtagging?rev=54#Working_points_and_scale_factors
[2] - https://github.com/cms-jet/PuppiSoftdropMassCorr/#get-uncorrected-puppi-soft-drop-mass-from-miniaod
[3] - https://twiki.cern.ch/twiki/bin/view/CMS/JetTopTagging?rev=14#13_TeV_working_points_CMSSW_8_0
[4] - https://twiki.cern.ch/twiki/bin/view/CMSPublic/ReMiniAOD03Feb2017Notes#Event_flags