### PR TITLE
Update the pythonn file to not neglect photon jets

### DIFF
--- a/test/b2gedmntuples_cfg.py
+++ b/test/b2gedmntuples_cfg.py
@@ -767,7 +767,7 @@ process.photonJetsUserData = cms.EDProducer(
 
 process.boostedJetUserDataAK8 = cms.EDProducer(
     'BoostedJetToolboxUserData',
-    jetLabel  = cms.InputTag('jetUserDataAK8'),
+    jetLabel  = cms.InputTag('photonJetsUserData'),
     puppiSDjetLabel = cms.InputTag('packedPatJetsAK8PFPuppiSoftDrop'),
     jetWithSubjetLabel = cms.InputTag('selectedPatJetsAK8PFCHSSoftDropPacked'),
     distMax = cms.double(0.8)
@@ -1009,7 +1009,6 @@ process.edmNtuplesOut = cms.OutputModule(
     "keep *_vertexInfo_*_*",
     "keep *_electrons_*_*",
     "keep *_photons_*_*",
-    "keep *_photonjets_*_*",
     "keep *_jetsAK4CHS_*_*",
     "keep *_jetsAK8CHS_*_*",
     "keep *_subjetsAK8CHS_*_*",


### PR DESCRIPTION
The photon jets collection was turned off by mistake during the development and thus always stored empty in this new tag. This fixes this